### PR TITLE
ranged iteration api

### DIFF
--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -13,7 +13,7 @@ use fvm_ipld_encoding::CborStore;
 use itertools::sorted;
 
 use super::ValueMut;
-use crate::node::{CollapsedNode, IterationStats, Link};
+use crate::node::{CollapsedNode, Link};
 use crate::root::version::{Version as AmtVersion, V0, V3};
 use crate::root::RootImpl;
 use crate::{
@@ -185,12 +185,6 @@ where
         }
 
         while i >= nodes_for_height(self.bit_width(), self.height() + 1) {
-            // FIXME: remove debugging
-            let bit_width = self.bit_width();
-            let height = self.height();
-            let nodes_for_height = nodes_for_height(bit_width, height + 1);
-            println!("Amt setting {i:?}. nodes_for_height({bit_width:?}, {height:?} + 1) = {nodes_for_height:?})");
-
             // node at index exists
             if !self.root.node.is_empty() {
                 // Parent node for expansion
@@ -382,7 +376,7 @@ where
         mut f: F,
     ) -> Result<(), Error>
     where
-        F: FnMut(u64, &V, IterationStats) -> anyhow::Result<bool>,
+        F: FnMut(u64, &V) -> anyhow::Result<bool>,
     {
         self.root
             .node

--- a/ipld/amt/src/lib.rs
+++ b/ipld/amt/src/lib.rs
@@ -15,7 +15,7 @@ mod value_mut;
 
 pub use self::amt::{Amt, Amtv0};
 pub use self::error::Error;
-pub(crate) use self::node::Node;
+pub use self::node::Node;
 pub use self::value_mut::ValueMut;
 
 const DEFAULT_BIT_WIDTH: u32 = 3;
@@ -25,7 +25,7 @@ const MAX_HEIGHT: u32 = 64;
 /// don't overflow u64::MAX when computing the length.
 pub const MAX_INDEX: u64 = (std::u64::MAX - 1) as u64;
 
-fn nodes_for_height(bit_width: u32, height: u32) -> u64 {
+pub fn nodes_for_height(bit_width: u32, height: u32) -> u64 {
     let height_log_two = bit_width as u64 * height as u64;
     if height_log_two >= 64 {
         return std::u64::MAX;

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -439,17 +439,17 @@ where
                 for (i, v) in (0..).zip(vals.iter()) {
                     // filter out leaf values between start and end index
                     let idx = offset + i;
-                    if idx < start_index {
-                        continue;
-                    } else if idx >= end_index {
-                        return Ok(true);
-                    }
+                    match idx {
+                        _ if idx < start_index => continue,
+                        _ if idx >= end_index => return Ok(true),
+                        _ => {
+                            if let Some(v) = v {
+                                let keep_going = f(idx, v)?;
 
-                    if let Some(v) = v {
-                        let keep_going = f(idx, v)?;
-
-                        if !keep_going {
-                            return Ok(false);
+                                if !keep_going {
+                                    return Ok(false);
+                                }
+                            }
                         }
                     }
                 }

--- a/ipld/amt/src/root.rs
+++ b/ipld/amt/src/root.rs
@@ -30,7 +30,7 @@ pub(crate) mod version {
 }
 
 #[derive(PartialEq, Debug)]
-pub(crate) struct RootImpl<V, Ver> {
+pub struct RootImpl<V, Ver> {
     pub bit_width: u32,
     pub height: u32,
     pub count: u64,

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -474,3 +474,21 @@ fn new_from_iter() {
     let expected: Vec<_> = data.into_iter().enumerate().collect();
     assert_eq!(expected, restored);
 }
+
+#[test]
+fn ranged_iteration() {
+    let mem = MemoryBlockstore::default();
+    let data: Vec<String> = (0..1000).map(|i| format!("thing{i}")).collect();
+    let k = Amt::<&str, _>::new_from_iter(&mem, data.iter().map(|s| &**s)).unwrap();
+
+    let a: Amt<String, _> = Amt::load(&k, &mem).unwrap();
+    let mut restored = Vec::new();
+    a.for_range_while(100, 200, |k, v| {
+        restored.push((k as usize, v.clone()));
+        Ok(true)
+    })
+    .unwrap();
+
+    let expected: Vec<(usize, String)> = (100..200).map(|i| (i, format!("thing{i}"))).collect();
+    assert_eq!(expected, restored);
+}


### PR DESCRIPTION
### POC/WIP

Skips expansion or iteration of subtrees that are not within the specified range. Motivated by enumeration features being spiked: https://github.com/helix-onchain/filecoin/pull/185

It will be most efficient to drop entire subtrees early so specifying ranges that are bounded at some `nodes_for_height(BITWIDTH, height)` multiple will be most efficient. Best to export a helper function that can help with this. 

[Discussion](https://github.com/helix-onchain/filecoin/issues/186)

